### PR TITLE
Compare spec with existing dataset, and only perform update if needed

### DIFF
--- a/.cplt.toml
+++ b/.cplt.toml
@@ -1,0 +1,2 @@
+[propose]
+allow_localhost_any = true

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ testbin/*
 *.swp
 *.swo
 *~
+/misc/
+/ARCHITECTURE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Agent Instructions
+
+## Project
+
+bqrator — Kubernetes operator that creates and manages BigQuery datasets as non-authoritative resources. Built with controller-runtime (Kubebuilder).
+
+## Commands
+
+```bash
+# Verify code (ALWAYS run before committing)
+mise run check        # fmt + staticcheck + vulncheck + deadcode + vet + helm-lint
+
+# Format
+mise run fmt          # gofumpt + go fix
+
+# Test
+mise run test         # envtest-backed controller tests
+
+# Generate CRDs and deepcopy
+mise run generate
+
+# Build
+mise run local:build
+```
+
+## Code Style
+
+- Formatter: `gofumpt` (not `gofmt`)
+- Linters: staticcheck, gosec, govulncheck, deadcode, go vet
+- Helm charts must pass `helm lint --strict`
+
+## Architecture Rules
+
+- Use dependency injection via interfaces for external clients (see `BigQueryWrapper` pattern in `controllers/bigquery_wrapper.go`)
+- Use Kubernetes Finalizers for external resource cleanup (finalizer: `bqrator.nais.io/finalizer`)
+- Use structured logging via `sigs.k8s.io/controller-runtime/pkg/log` with context
+- Return `ctrl.Result{}, err` from reconcilers — never panic on reconcile errors
+- CRD types come from `github.com/nais/liberator`
+
+## Key Files
+
+| Path                                        | Purpose                                 |
+|---------------------------------------------|-----------------------------------------|
+| `main.go`                                   | Controller-runtime manager setup and DI |
+| `controllers/bigquerydataset_controller.go` | Core reconciliation logic               |
+| `controllers/bigquery_wrapper.go`           | GCP BigQuery client interface layer     |
+| `pkg/metrics/`                              | Prometheus metrics                      |
+| `charts/`                                   | Helm deployment chart                   |
+
+## Do NOT
+
+- Add direct GCP client calls without going through the wrapper interface
+- Use `panic` or `os.Exit` in reconciliation paths
+- Skip `mise run check` before declaring work complete
+- Modify CRD types here (they live in `github.com/nais/liberator`)

--- a/controllers/bigquerydataset_controller.go
+++ b/controllers/bigquerydataset_controller.go
@@ -158,11 +158,16 @@ func (r *BigQueryDatasetReconciler) onUpdate(ctx context.Context, dataset google
 	}
 	metadata.SetLabel("team", dataset.GetNamespace())
 
-	err = r.bigqueryClient.Update(ctx, dataset.Spec.Project, dataset.Spec.Name, metadata, existing.ETag)
-	if err != nil {
-		log.Error(err, "unable to update dataset")
-		return err
+	if metadataEqual(dataset, existing, access) {
+		log.Info("No-op update detected, skipping GCP update call")
+	} else {
+		err = r.bigqueryClient.Update(ctx, dataset.Spec.Project, dataset.Spec.Name, metadata, existing.ETag)
+		if err != nil {
+			log.Error(err, "unable to update dataset")
+			return err
+		}
 	}
+
 	dataset.Status.LastModifiedTime = int(time.Now().Unix())
 	meta.SetStatusCondition(&dataset.Status.Conditions, metav1.Condition{
 		Type:               "Ready",
@@ -178,6 +183,53 @@ func (r *BigQueryDatasetReconciler) onUpdate(ctx context.Context, dataset google
 		return err
 	}
 	return nil
+}
+
+// metadataEqual returns true when the desired state derived from the k8s resource
+// (and the already-merged computedAccess list) is identical to the current GCP state.
+// When it returns true, the BigQuery Update API call can be skipped.
+func metadataEqual(dataset google_nais_io_v1.BigQueryDataset, existing *bigquery.DatasetMetadata, computedAccess []*bigquery.AccessEntry) bool {
+	if dataset.Spec.Name != existing.Name {
+		return false
+	}
+	if dataset.Spec.Description != existing.Description {
+		return false
+	}
+	if !accessSetEqual(computedAccess, existing.Access) {
+		return false
+	}
+	if existing.Labels["team"] != dataset.GetNamespace() {
+		return false
+	}
+	if metav1.HasLabel(dataset.ObjectMeta, "app") {
+		if existing.Labels["app"] != dataset.GetLabels()["app"] {
+			return false
+		}
+	}
+	return true
+}
+
+// accessSetEqual reports whether a and b contain the same access entries,
+// regardless of order. Entries are compared by Role, EntityType, and Entity.
+func accessSetEqual(a, b []*bigquery.AccessEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	type key struct {
+		Role       bigquery.AccessRole
+		EntityType bigquery.EntityType
+		Entity     string
+	}
+	set := make(map[key]struct{}, len(a))
+	for _, entry := range a {
+		set[key{entry.Role, entry.EntityType, entry.Entity}] = struct{}{}
+	}
+	for _, entry := range b {
+		if _, ok := set[key{entry.Role, entry.EntityType, entry.Entity}]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *BigQueryDatasetReconciler) onDelete(ctx context.Context, dataset google_nais_io_v1.BigQueryDataset) (ctrl.Result, error) {

--- a/controllers/bigquerydataset_controller.go
+++ b/controllers/bigquerydataset_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"slices"
 	"strings"
@@ -209,8 +210,27 @@ func metadataEqual(dataset google_nais_io_v1.BigQueryDataset, existing *bigquery
 	return true
 }
 
+// accessSubEntity returns a string that uniquely identifies the sub-entity of
+// an AccessEntry for ViewEntity, RoutineEntity, and DatasetEntity types, whose
+// Entity field is always empty. Returns "" for standard entity types.
+func accessSubEntity(e *bigquery.AccessEntry) string {
+	if e.View != nil {
+		return fmt.Sprintf("%s/%s/%s", e.View.ProjectID, e.View.DatasetID, e.View.TableID)
+	}
+	if e.Routine != nil {
+		return fmt.Sprintf("%s/%s/%s", e.Routine.ProjectID, e.Routine.DatasetID, e.Routine.RoutineID)
+	}
+	if e.Dataset != nil && e.Dataset.Dataset != nil {
+		types := slices.Clone(e.Dataset.TargetTypes)
+		slices.Sort(types)
+		return fmt.Sprintf("%s/%s/%s", e.Dataset.Dataset.ProjectID, e.Dataset.Dataset.DatasetID, strings.Join(types, ","))
+	}
+	return ""
+}
+
 // accessSetEqual reports whether a and b contain the same access entries,
-// regardless of order. Entries are compared by Role, EntityType, and Entity.
+// regardless of order. Entries are compared by Role, EntityType, Entity, and
+// SubEntity (for View, Routine, and Dataset grants where Entity is always "").
 func accessSetEqual(a, b []*bigquery.AccessEntry) bool {
 	if len(a) != len(b) {
 		return false
@@ -219,13 +239,14 @@ func accessSetEqual(a, b []*bigquery.AccessEntry) bool {
 		Role       bigquery.AccessRole
 		EntityType bigquery.EntityType
 		Entity     string
+		SubEntity  string
 	}
 	set := make(map[key]struct{}, len(a))
 	for _, entry := range a {
-		set[key{entry.Role, entry.EntityType, entry.Entity}] = struct{}{}
+		set[key{entry.Role, entry.EntityType, entry.Entity, accessSubEntity(entry)}] = struct{}{}
 	}
 	for _, entry := range b {
-		if _, ok := set[key{entry.Role, entry.EntityType, entry.Entity}]; !ok {
+		if _, ok := set[key{entry.Role, entry.EntityType, entry.Entity, accessSubEntity(entry)}]; !ok {
 			return false
 		}
 	}

--- a/controllers/bigquerydataset_controller_test.go
+++ b/controllers/bigquerydataset_controller_test.go
@@ -242,8 +242,7 @@ func TestBigqueryDatasetControllerDelete(t *testing.T) {
 	}
 
 	gotten = eventually(100*time.Millisecond, 10, func() bool {
-		_, ok := bqMock.state[dataset.Spec.Project+"_"+dataset.Spec.Name]
-		return !ok
+		return !bqMock.HasDataset(dataset.Spec.Project, dataset.Spec.Name)
 	})
 	if !gotten {
 		t.Fatalf("Failed delete datset from state")
@@ -289,6 +288,210 @@ func TestRemoveDeletedServiceAccounts(t *testing.T) {
 		actual := removeDeletedServiceAccounts(existing)
 		if !cmp.Equal(expected, actual) {
 			t.Error(cmp.Diff(expected, actual))
+		}
+	})
+}
+
+func TestBigqueryDatasetControllerCascadingDeleteOnlyChange(t *testing.T) {
+	ctx := context.Background()
+
+	dataset := naisv1.BigQueryDataset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cascading-noop",
+			Namespace: "default",
+		},
+		Spec: naisv1.BigQueryDatasetSpec{
+			Name:            "test-cascading-noop-dataset",
+			Description:     "test description",
+			Location:        "europe-north1",
+			Project:         "gcpproject",
+			CascadingDelete: false,
+		},
+	}
+
+	if err := k8sClient.Create(ctx, &dataset); err != nil {
+		t.Fatalf("Failed to create dataset: %v", err)
+	}
+
+	// Wait for initial reconcile to complete (CreationTime set means onCreate ran)
+	var err error
+	gotten := eventually(100*time.Millisecond, 10, func() bool {
+		err = k8sClient.Get(ctx, types.NamespacedName{Namespace: dataset.Namespace, Name: dataset.Name}, &dataset)
+		return err == nil && dataset.Status.CreationTime > 0
+	})
+	if err != nil {
+		t.Fatalf("Failed to get dataset after creation: %v", err)
+	} else if !gotten {
+		t.Fatal("Dataset never reached Created state")
+	}
+
+	// Record the update count after initial creation (onCreate uses Create, not Update)
+	updateCountAfterCreate := bqMock.GetUpdateCount()
+
+	// Change only CascadingDelete — this must not trigger a GCP Update call
+	creationHash := dataset.Status.SynchronizationHash
+	dataset.Spec.CascadingDelete = true
+	if err := k8sClient.Update(ctx, &dataset); err != nil {
+		t.Fatalf("Failed to update dataset with CascadingDelete=true: %v", err)
+	}
+
+	// Wait for the controller to reconcile and update the hash in status
+	gotten = eventually(100*time.Millisecond, 15, func() bool {
+		err = k8sClient.Get(ctx, types.NamespacedName{Namespace: dataset.Namespace, Name: dataset.Name}, &dataset)
+		return err == nil && dataset.Status.SynchronizationHash != creationHash
+	})
+	if err != nil {
+		t.Fatalf("Failed to get dataset after CascadingDelete change: %v", err)
+	} else if !gotten {
+		t.Fatal("SynchronizationHash was never updated after CascadingDelete-only change")
+	}
+
+	// The GCP Update must NOT have been called — only CascadingDelete changed, which
+	// has no effect on the BigQuery dataset itself.
+	if bqMock.GetUpdateCount() != updateCountAfterCreate {
+		t.Errorf("expected no GCP Update call for a CascadingDelete-only change, but updateCount changed from %d to %d",
+			updateCountAfterCreate, bqMock.GetUpdateCount())
+	}
+}
+
+func TestMetadataEqual(t *testing.T) {
+	makeDataset := func(name, ns, desc string, appLabel string, access []naisv1.DatasetAccess) naisv1.BigQueryDataset {
+		labels := map[string]string{}
+		if appLabel != "" {
+			labels["app"] = appLabel
+		}
+		return naisv1.BigQueryDataset{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: labels},
+			Spec: naisv1.BigQueryDatasetSpec{
+				Name:        name,
+				Description: desc,
+				Access:      access,
+			},
+		}
+	}
+
+	baseAccess := []*bigquery.AccessEntry{
+		{Role: "READER", EntityType: bigquery.UserEmailEntity, Entity: "user@example.com"},
+	}
+	baseExisting := &bigquery.DatasetMetadata{
+		Name:        "ds",
+		Description: "desc",
+		Access:      baseAccess,
+		Labels:      map[string]string{"team": "myns"},
+	}
+	baseDataset := makeDataset("ds", "myns", "desc", "", []naisv1.DatasetAccess{
+		{Role: "READER", UserByEmail: "user@example.com"},
+	})
+
+	t.Run("equal when nothing changed", func(t *testing.T) {
+		if !metadataEqual(baseDataset, baseExisting, baseAccess) {
+			t.Error("expected equal")
+		}
+	})
+
+	t.Run("not equal when name differs", func(t *testing.T) {
+		other := *baseExisting
+		other.Name = "other"
+		if metadataEqual(baseDataset, &other, baseAccess) {
+			t.Error("expected not equal")
+		}
+	})
+
+	t.Run("not equal when description differs", func(t *testing.T) {
+		other := *baseExisting
+		other.Description = "changed"
+		if metadataEqual(baseDataset, &other, baseAccess) {
+			t.Error("expected not equal")
+		}
+	})
+
+	t.Run("not equal when access differs", func(t *testing.T) {
+		otherAccess := []*bigquery.AccessEntry{
+			{Role: "WRITER", EntityType: bigquery.UserEmailEntity, Entity: "other@example.com"},
+		}
+		if metadataEqual(baseDataset, baseExisting, otherAccess) {
+			t.Error("expected not equal")
+		}
+	})
+
+	t.Run("equal with access in different order", func(t *testing.T) {
+		twoAccess := []*bigquery.AccessEntry{
+			{Role: "READER", EntityType: bigquery.UserEmailEntity, Entity: "a@example.com"},
+			{Role: "WRITER", EntityType: bigquery.UserEmailEntity, Entity: "b@example.com"},
+		}
+		existing := &bigquery.DatasetMetadata{
+			Name: "ds", Description: "desc",
+			Access: []*bigquery.AccessEntry{
+				{Role: "WRITER", EntityType: bigquery.UserEmailEntity, Entity: "b@example.com"},
+				{Role: "READER", EntityType: bigquery.UserEmailEntity, Entity: "a@example.com"},
+			},
+			Labels: map[string]string{"team": "myns"},
+		}
+		if !metadataEqual(baseDataset, existing, twoAccess) {
+			t.Error("expected equal (order-insensitive)")
+		}
+	})
+
+	t.Run("not equal when team label differs", func(t *testing.T) {
+		other := *baseExisting
+		other.Labels = map[string]string{"team": "wrongns"}
+		if metadataEqual(baseDataset, &other, baseAccess) {
+			t.Error("expected not equal")
+		}
+	})
+
+	t.Run("not equal when app label differs", func(t *testing.T) {
+		ds := makeDataset("ds", "myns", "desc", "myapp", []naisv1.DatasetAccess{
+			{Role: "READER", UserByEmail: "user@example.com"},
+		})
+		other := *baseExisting
+		other.Labels = map[string]string{"team": "myns", "app": "otherapp"}
+		if metadataEqual(ds, &other, baseAccess) {
+			t.Error("expected not equal")
+		}
+	})
+
+	t.Run("equal when app label matches", func(t *testing.T) {
+		ds := makeDataset("ds", "myns", "desc", "myapp", []naisv1.DatasetAccess{
+			{Role: "READER", UserByEmail: "user@example.com"},
+		})
+		other := *baseExisting
+		other.Labels = map[string]string{"team": "myns", "app": "myapp"}
+		if !metadataEqual(ds, &other, baseAccess) {
+			t.Error("expected equal")
+		}
+	})
+}
+
+func TestAccessSetEqual(t *testing.T) {
+	entry := func(role, entity string) *bigquery.AccessEntry {
+		return &bigquery.AccessEntry{Role: bigquery.AccessRole(role), EntityType: bigquery.UserEmailEntity, Entity: entity}
+	}
+
+	t.Run("both nil", func(t *testing.T) {
+		if !accessSetEqual(nil, nil) {
+			t.Error("expected equal")
+		}
+	})
+	t.Run("same single entry", func(t *testing.T) {
+		a := []*bigquery.AccessEntry{entry("READER", "u@x.com")}
+		b := []*bigquery.AccessEntry{entry("READER", "u@x.com")}
+		if !accessSetEqual(a, b) {
+			t.Error("expected equal")
+		}
+	})
+	t.Run("different length", func(t *testing.T) {
+		a := []*bigquery.AccessEntry{entry("READER", "u@x.com")}
+		var b []*bigquery.AccessEntry
+		if accessSetEqual(a, b) {
+			t.Error("expected not equal")
+		}
+	})
+	t.Run("different role", func(t *testing.T) {
+		a := []*bigquery.AccessEntry{entry("READER", "u@x.com")}
+		b := []*bigquery.AccessEntry{entry("WRITER", "u@x.com")}
+		if accessSetEqual(a, b) {
+			t.Error("expected not equal")
 		}
 	})
 }

--- a/controllers/bigquerydataset_controller_test.go
+++ b/controllers/bigquerydataset_controller_test.go
@@ -467,6 +467,30 @@ func TestAccessSetEqual(t *testing.T) {
 	entry := func(role, entity string) *bigquery.AccessEntry {
 		return &bigquery.AccessEntry{Role: bigquery.AccessRole(role), EntityType: bigquery.UserEmailEntity, Entity: entity}
 	}
+	viewEntry := func(role, projectID, datasetID, tableID string) *bigquery.AccessEntry {
+		return &bigquery.AccessEntry{
+			Role:       bigquery.AccessRole(role),
+			EntityType: bigquery.ViewEntity,
+			View:       &bigquery.Table{ProjectID: projectID, DatasetID: datasetID, TableID: tableID},
+		}
+	}
+	routineEntry := func(role, projectID, datasetID, routineID string) *bigquery.AccessEntry {
+		return &bigquery.AccessEntry{
+			Role:       bigquery.AccessRole(role),
+			EntityType: bigquery.RoutineEntity,
+			Routine:    &bigquery.Routine{ProjectID: projectID, DatasetID: datasetID, RoutineID: routineID},
+		}
+	}
+	datasetEntry := func(role, projectID, datasetID string, targetTypes []string) *bigquery.AccessEntry {
+		return &bigquery.AccessEntry{
+			Role:       bigquery.AccessRole(role),
+			EntityType: bigquery.DatasetEntity,
+			Dataset: &bigquery.DatasetAccessEntry{
+				Dataset:     &bigquery.Dataset{ProjectID: projectID, DatasetID: datasetID},
+				TargetTypes: targetTypes,
+			},
+		}
+	}
 
 	t.Run("both nil", func(t *testing.T) {
 		if !accessSetEqual(nil, nil) {
@@ -492,6 +516,92 @@ func TestAccessSetEqual(t *testing.T) {
 		b := []*bigquery.AccessEntry{entry("WRITER", "u@x.com")}
 		if accessSetEqual(a, b) {
 			t.Error("expected not equal")
+		}
+	})
+	t.Run("identical view grant lists are equal", func(t *testing.T) {
+		a := []*bigquery.AccessEntry{
+			viewEntry("READER", "proj", "ds", "viewA"),
+			viewEntry("READER", "proj", "ds", "viewB"),
+		}
+		b := []*bigquery.AccessEntry{
+			viewEntry("READER", "proj", "ds", "viewA"),
+			viewEntry("READER", "proj", "ds", "viewB"),
+		}
+		if !accessSetEqual(a, b) {
+			t.Error("expected equal")
+		}
+	})
+	t.Run("view grants differing in one view are not equal", func(t *testing.T) {
+		a := []*bigquery.AccessEntry{
+			viewEntry("READER", "proj", "ds", "viewA"),
+			viewEntry("READER", "proj", "ds", "viewB"),
+		}
+		b := []*bigquery.AccessEntry{
+			viewEntry("READER", "proj", "ds", "viewA"),
+			viewEntry("READER", "proj", "ds", "viewC"),
+		}
+		if accessSetEqual(a, b) {
+			t.Error("expected not equal")
+		}
+	})
+	t.Run("identical routine grant lists are equal", func(t *testing.T) {
+		a := []*bigquery.AccessEntry{
+			routineEntry("READER", "proj", "ds", "routineA"),
+			routineEntry("READER", "proj", "ds", "routineB"),
+		}
+		b := []*bigquery.AccessEntry{
+			routineEntry("READER", "proj", "ds", "routineA"),
+			routineEntry("READER", "proj", "ds", "routineB"),
+		}
+		if !accessSetEqual(a, b) {
+			t.Error("expected equal")
+		}
+	})
+	t.Run("routine grants differing in routine ID are not equal", func(t *testing.T) {
+		a := []*bigquery.AccessEntry{
+			routineEntry("READER", "proj", "ds", "routineA"),
+		}
+		b := []*bigquery.AccessEntry{
+			routineEntry("READER", "proj", "ds", "routineB"),
+		}
+		if accessSetEqual(a, b) {
+			t.Error("expected not equal")
+		}
+	})
+	t.Run("identical dataset grant lists are equal", func(t *testing.T) {
+		a := []*bigquery.AccessEntry{
+			datasetEntry("READER", "proj", "dsA", []string{"VIEWS"}),
+		}
+		b := []*bigquery.AccessEntry{
+			datasetEntry("READER", "proj", "dsA", []string{"VIEWS"}),
+		}
+		if !accessSetEqual(a, b) {
+			t.Error("expected equal")
+		}
+	})
+	t.Run("dataset grants differing in dataset ID are not equal", func(t *testing.T) {
+		a := []*bigquery.AccessEntry{
+			datasetEntry("READER", "proj", "dsA", []string{"VIEWS"}),
+		}
+		b := []*bigquery.AccessEntry{
+			datasetEntry("READER", "proj", "dsB", []string{"VIEWS"}),
+		}
+		if accessSetEqual(a, b) {
+			t.Error("expected not equal")
+		}
+	})
+	t.Run("dataset entry with nil inner Dataset does not panic and compares equal", func(t *testing.T) {
+		nilDataset := func(role string) *bigquery.AccessEntry {
+			return &bigquery.AccessEntry{
+				Role:       bigquery.AccessRole(role),
+				EntityType: bigquery.DatasetEntity,
+				Dataset:    &bigquery.DatasetAccessEntry{Dataset: nil},
+			}
+		}
+		a := []*bigquery.AccessEntry{nilDataset("READER")}
+		b := []*bigquery.AccessEntry{nilDataset("READER")}
+		if !accessSetEqual(a, b) {
+			t.Error("expected equal (both have nil inner Dataset)")
 		}
 	})
 }

--- a/controllers/bigquerydataset_controller_test.go
+++ b/controllers/bigquerydataset_controller_test.go
@@ -245,7 +245,7 @@ func TestBigqueryDatasetControllerDelete(t *testing.T) {
 		return !bqMock.HasDataset(dataset.Spec.Project, dataset.Spec.Name)
 	})
 	if !gotten {
-		t.Fatalf("Failed delete datset from state")
+		t.Fatalf("Failed delete dataset from state")
 	}
 }
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -105,10 +106,14 @@ func setupBigQueryDatasetController(ctx context.Context) {
 }
 
 type bqMocker struct {
-	state map[string]*bigquery.DatasetMetadata
+	mu          sync.Mutex
+	state       map[string]*bigquery.DatasetMetadata
+	updateCount int
 }
 
 func (b *bqMocker) Get(ctx context.Context, projectID, name string) (*bigquery.DatasetMetadata, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	fmt.Println("GET", projectID, name)
 	dm, ok := b.state[projectID+"_"+name]
 	if !ok {
@@ -118,6 +123,8 @@ func (b *bqMocker) Get(ctx context.Context, projectID, name string) (*bigquery.D
 }
 
 func (b *bqMocker) Create(ctx context.Context, projectID string, dataset *bigquery.DatasetMetadata) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	fmt.Println("CREATE", projectID, dataset.Name)
 	if _, ok := b.state[projectID+"_"+dataset.Name]; ok {
 		return &googleapi.Error{
@@ -130,7 +137,10 @@ func (b *bqMocker) Create(ctx context.Context, projectID string, dataset *bigque
 }
 
 func (b *bqMocker) Update(ctx context.Context, projectID, name string, dataset bigquery.DatasetMetadataToUpdate, etag string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	fmt.Println("UPDATE", projectID, name)
+	b.updateCount++
 	dm, ok := b.state[projectID+"_"+name]
 	if !ok {
 		return fmt.Errorf("dataset not found")
@@ -154,7 +164,22 @@ func (b *bqMocker) Update(ctx context.Context, projectID, name string, dataset b
 	return nil
 }
 
+func (b *bqMocker) GetUpdateCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.updateCount
+}
+
+func (b *bqMocker) HasDataset(project, name string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	_, ok := b.state[project+"_"+name]
+	return ok
+}
+
 func (b *bqMocker) Delete(ctx context.Context, projectID, name string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	fmt.Println("DELETE", projectID, name)
 	if _, ok := b.state[projectID+"_"+name]; !ok {
 		return fmt.Errorf("dataset not found")

--- a/mise.toml
+++ b/mise.toml
@@ -75,7 +75,7 @@ run = 'KUBEBUILDER_ASSETS="$(pwd)/$(setup-envtest use $ENVTEST_K8S_VERSION --bin
 
 [tasks."local:build"]
 description = "Build manager binary"
-depends = ["generate", "fmt", "vet"]
+depends = ["generate", "fmt", "check:vet"]
 run = "go build -o bin/manager main.go"
 
 [tasks."local:run"]


### PR DESCRIPTION
This will allow the user to change `cascadingDelete` without triggering updates to the actual datasets in Google.